### PR TITLE
v2.2.2 changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Shelby Bennett, Erin Young, Curtis Kapsak, & Kutluhan Incekara
 
 ARG SAMTOOLS_VER="1.18"
-ARG TBP_PARSER_VER="2.2.1"
+ARG TBP_PARSER_VER="2.2.2"
 
 FROM ubuntu:jammy AS builder
 

--- a/docs/inputs/theiaprok.md
+++ b/docs/inputs/theiaprok.md
@@ -29,7 +29,7 @@ The following optional inputs are also available for user modification on Terra:
 | `merlin_magic` | **tbp_parser_coverage_regions_bed** | File | A BED file containing the regions to calculate percent coverage for | [tbdb-modified-regions.md](https://github.com/theiagen/tbp-parser/blob/main/data/tbdb-modified-regions.bed) |
 | `merlin_magic` | **tbp_parser_coverage_threshold** | Int | The minimum percentage of a region that has depth above the threshold set by `min_depth` (used for a gene/locus to pass QC) | 100 |
 | `merlin_magic` | **tbp_parser_debug** | Boolean | Set to `false` to turn off debug mode for `tbp-parser` | `true` |
-| `merlin_magic` | **tbp_parser_docker_image** | String | The Docker image to use when running `tbp-parser` | "us-docker.pkg.dev/general-theiagen/theiagen/tbp-parser:2.2.1" |
+| `merlin_magic` | **tbp_parser_docker_image** | String | The Docker image to use when running `tbp-parser` | "us-docker.pkg.dev/general-theiagen/theiagen/tbp-parser:2.2.2" |
 | `merlin_magic` | **tbp_parser_etha237_frequency** | Float | Minimum frequency for a mutation in ethA at protein position 237 to pass QC in `tbp-parser` | 0.1 |
 | `merlin_magic` | **tbp_parser_expert_rule_regions_bed** | File | A file that contains the regions where R mutations and expert rules are applied |  |
 | `merlin_magic` | **tbp_parser_min_depth** | Int | Minimum depth for a variant to pass QC in tbp_parser | 10 |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ title: Getting Started
 We highly recommend using the following Docker iamge to run tbp-parser:
 
 ``` bash
-docker pull us-docker.pkg.dev/general-theiagen/theiagen/tbp-parser:2.2.1 #(1)!
+docker pull us-docker.pkg.dev/general-theiagen/theiagen/tbp-parser:2.2.2 #(1)!
 ```
 
 1. We host our Docker images on the Google Artifact Registry so that they are always availble for usage.
@@ -21,7 +21,7 @@ docker run -it --entrypoint=/bin/bash us-docker.pkg.dev/general-theiagen/theiage
 
 # Once inside the container interactively, you can run the tbp-parser tool
 python3 /tbp-parser/tbp_parser/tbp_parser.py -v
-# v2.2.1
+# v2.2.2
 ```
 
 ### Locally with Python

--- a/docs/versioning/exhaustive.md
+++ b/docs/versioning/exhaustive.md
@@ -66,6 +66,8 @@ The following is a list of every version of `tbp-parser` and a short summary of 
     - Earlier versions are now deprecated and will no longer be supported.
 - v2.1.1 - adds the source and comment fields from TBDB to the Laboratorian report; fixes a bug where mmpR5 was not being completly renamed to Rv0678; fixes a bug where mutations that didn't share the same position were being compared
 - v2.2.0 - removes ciprofloxacin, fluoroquinolones, and ofloxacin from gyrA and gyrB and aminoglycosides from rrs in the `globals.GENE_TO_ANTIMICROBIAL_DRUG_NAME` dictionary; if a drug is missing in the TBProfiler JSON's gene_associated_drug field that is present in that global dictionary, it will be added for the mutation.
+- v2.2.1 - fixes a bug where rifampicin was not renamed to rifampin, which caused duplicate lines to appear in the Laboratorian report.
+- v2.2.2 - removes the high-level and low-level resistance comments from the LIMS report
 
 ---
 

--- a/tbp_parser/LIMS.py
+++ b/tbp_parser/LIMS.py
@@ -142,7 +142,6 @@ class LIMS:
         mdl_interpretations = globals.DF_LABORATORIAN[(globals.DF_LABORATORIAN["tbprofiler_gene_name"] == gene) & (globals.DF_LABORATORIAN["antimicrobial"] == antimicrobial_name)]["mdl_interpretation"].tolist()
         warnings = globals.DF_LABORATORIAN[(globals.DF_LABORATORIAN["tbprofiler_gene_name"] == gene) & (globals.DF_LABORATORIAN["antimicrobial"] == antimicrobial_name)]["warning"].tolist()
         read_supports = globals.DF_LABORATORIAN[(globals.DF_LABORATORIAN["tbprofiler_gene_name"] == gene) & (globals.DF_LABORATORIAN["antimicrobial"] == antimicrobial_name)]["read_support"].tolist()  
-        tbdb_comments = globals.DF_LABORATORIAN[(globals.DF_LABORATORIAN["tbprofiler_gene_name"] == gene) & (globals.DF_LABORATORIAN["antimicrobial"] == antimicrobial_name)]["tbdb_comment"].tolist()
                  
         self.logger.debug("LIMS:The following mutations belong to this gene ({}) and are associated with this drug ({})".format(gene, antimicrobial_name))
         self.logger.debug("LIMS:Amino acid mutations: {}".format(aa_mutations_per_gene))
@@ -268,13 +267,7 @@ class LIMS:
               # the following if only captures synonymous mutations if rpoB RRDR mutations
               if mutation_type == "synonymous_variant":
                 substitution = "{} [synonymous]".format(substitution)
-              
-              # add a high-level or low-level resistance annotation to the LIMS report
-              for key, value in globals.COMMENT_TO_LIMS.items():
-                if key in tbdb_comments[index]:
-                  substitution = "{} [{}]".format(substitution, value)
-                  break
-              
+                      
               # add the formatted mutation to mutations_per_gene dictionary (formatted as a list)
               if gene not in mutations_per_gene.keys():
                 mutations_per_gene[gene] = [substitution]

--- a/tbp_parser/Variant.py
+++ b/tbp_parser/Variant.py
@@ -120,7 +120,6 @@ class Variant:
   
       self.logger.debug("VAR:The annotation dictionary has all gene associated drugs included; it now has a length of {}".format(len(self.annotation_dictionary)))
     
-    
     else:
       # possibilities 1b and 2: the annotation field has no content or the field does not exist
       self.logger.debug("VAR:The annotation field has no content or does not exist. Now iterating through gene associated drugs and gene-drug combination dictionary.")

--- a/tbp_parser/globals.py
+++ b/tbp_parser/globals.py
@@ -283,17 +283,6 @@ ANTIMICROBIAL_DRUG_NAME_TO_GENE_NAME = {
 }
 
 """
-A dictionary that converts the mutation comment to a reportable LIMS values for the corresponding mutation
-The key is the search term in the comment (comment.contains(key)) and the value will be output in square brackets
-"""
-global COMMENT_TO_LIMS
-COMMENT_TO_LIMS = {
-  "Low-level resistance (multiple, genetically linked low-level resistance mutations are additive and confer high-level resistance)": "Low-level resistance",
-  "High-level resistance": "High-level resistance"
-}
-
-
-"""
 A dictionary that will contain the percent coverage for each gene
 """
 global COVERAGE_DICTIONARY


### PR DESCRIPTION
#tbp-parser v2.2.2.

This release removes the high-level and low-level resistance tags from LIMS